### PR TITLE
[Hotfix] 사진 인덱스 0 고정 취소

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         minSdk 23
         compileSdkVersion 34
         targetSdk 34
-        versionCode 6
-        versionName "1.1.4"
+        versionCode 8
+        versionName "1.1.6"
 
 
         buildConfigField "String", "BASE_URL", properties["BASE_URL"]

--- a/app/src/main/java/com/eatssu/android/data/dto/response/ReviewListResponse.kt
+++ b/app/src/main/java/com/eatssu/android/data/dto/response/ReviewListResponse.kt
@@ -38,7 +38,7 @@ fun GetReviewListResponse.toReviewList(): List<Review> {
             tasteGrade = data.tasteRating,
             writeDate = data.writedAt,
             content = data.content,
-            imgUrlList = data.imageUrls[0] ?: ""
+            imgUrlList = data.imageUrls
         )
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/model/Review.kt
+++ b/app/src/main/java/com/eatssu/android/data/model/Review.kt
@@ -14,5 +14,5 @@ data class Review(
     val writeDate: String,
 
     val content: String,
-    val imgUrlList: String,
+    val imgUrlList: ArrayList<String?>,
 )

--- a/app/src/main/java/com/eatssu/android/ui/mypage/myreview/MyReviewAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/ui/mypage/myreview/MyReviewAdapter.kt
@@ -28,11 +28,11 @@ class MyReviewAdapter(private val dataList: List<MyReviewResponse.DataList>) :
             binding.tvTasteRating.text = dataList[position].tasteRating.toString()
             binding.tvAmountRating.text = dataList[position].amountRating.toString()
             binding.tvWriterNickname.text = MySharedPreferences.getUserName(binding.root.context)
-            val img: String = dataList[position].imgUrlList[0]// The list of image URLs
+//            val img: String = dataList[position].imgUrlList[0]// The list of image URLs
 
             val imageView: ImageView = binding.ivReviewPhoto
 
-            if (dataList[position].imgUrlList[0].isEmpty()) {
+            if (dataList[position].imgUrlList.isEmpty()) {
                 imageView.visibility = View.GONE
             } else {
                 Glide.with(itemView)

--- a/app/src/main/java/com/eatssu/android/ui/review/list/ReviewAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/ui/review/list/ReviewAdapter.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -32,21 +31,18 @@ class ReviewAdapter(private val dataList: List<Review>) :
                 binding.tvTotalRating.text = mainGrade.toString()
                 binding.tvTasteRating.text = tasteGrade.toString()
                 binding.tvAmountRating.text = amountGrade.toString()
-
             }
 
-            val imgUrl: String? = data.imgUrlList
+            binding.ivReviewPhoto.let {
+                if (data.imgUrlList.isEmpty()) {
+                    it.visibility = View.GONE
+                } else {
 
-            val imageView: ImageView = binding.ivReviewPhoto
-
-            if (imgUrl.isNullOrEmpty()) {
-                imageView.visibility = View.GONE
-            } else {
-
-                Glide.with(itemView)
-                    .load(imgUrl)
-                    .into(imageView)
-                imageView.visibility = View.VISIBLE
+                    Glide.with(itemView)
+                        .load(data.imgUrlList[0])
+                        .into(it)
+                    it.visibility = View.VISIBLE
+                }
             }
 
             binding.btnDetail.setOnClickListener {
@@ -70,34 +66,34 @@ class ReviewAdapter(private val dataList: List<Review>) :
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(position: Int) {
-            val data = dataList?.get(position)
-            binding.tvWriterNickname.text = data?.writerNickname.toString()
-            binding.tvReviewItemComment.text = data?.content
-            binding.tvReviewItemDate.text = data?.writeDate
-            binding.tvMenuName.text = data?.menu
 
-            binding.tvTotalRating.text = data?.mainGrade?.toString()
-            binding.tvTasteRating.text = data?.tasteGrade?.toString()
-            binding.tvAmountRating.text = data?.amountGrade?.toString()
+            val data = dataList[position].apply {
+                binding.tvWriterNickname.text = writerNickname
+                binding.tvReviewItemComment.text = content
+                binding.tvReviewItemDate.text = writeDate
+                binding.tvMenuName.text = menu
 
-            val imgUrlList: String? = data?.imgUrlList
+                binding.tvTotalRating.text = mainGrade.toString()
+                binding.tvTasteRating.text = tasteGrade.toString()
+                binding.tvAmountRating.text = amountGrade.toString()
+            }
 
-            val imageView: ImageView = binding.ivReviewPhoto
+            binding.ivReviewPhoto.let {
+                if (data.imgUrlList.isEmpty()) {
+                    it.visibility = View.GONE
+                } else {
 
-            if (imgUrlList.isNullOrEmpty()) {
-                imageView.visibility = View.GONE
-            } else {
-                val imageUrl = imgUrlList[0]
-
-                Glide.with(itemView)
-                    .load(imageUrl)
-                    .into(imageView)
-                imageView.visibility = View.VISIBLE
+                    Glide.with(itemView)
+                        .load(data.imgUrlList[0])
+                        .into(it)
+                    it.visibility = View.VISIBLE
+                }
             }
 
             binding.tvReviewItemReport.setOnClickListener {
-                if (data?.isWriter == false) {
-                    val intent = Intent(binding.tvReviewItemReport.context, ReportActivity::class.java)
+                if (!data.isWriter) {
+                    val intent =
+                        Intent(binding.tvReviewItemReport.context, ReportActivity::class.java)
                     intent.putExtra("reviewId", data.reviewId)
                     intent.putExtra("menu", data.menu)
                     ContextCompat.startActivity(binding.tvReviewItemReport.context, intent, null)
@@ -128,14 +124,14 @@ class ReviewAdapter(private val dataList: List<Review>) :
     }
 
     override fun getItemViewType(position: Int): Int {
-        return if (dataList?.get(position)?.isWriter == true) {
+        return if (dataList[position].isWriter) {
             VIEW_TYPE_MY_REVIEW
         } else {
             VIEW_TYPE_OTHERS_REVIEW
         }
     }
 
-    override fun getItemCount(): Int = dataList?.size ?: 0
+    override fun getItemCount(): Int = dataList.size
 
     companion object {
         private const val VIEW_TYPE_MY_REVIEW = 1

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -191,7 +191,8 @@
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/vp_main"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@color/gray100"
             android:layout_gravity="top"
             android:nestedScrollingEnabled="false"
             tools:ignore="MissingConstraints" />


### PR DESCRIPTION
## 관련 이슈

- Resolves #150 

## 개요

> 사진 인덱스를 0으로 고정해두어서 생긴 에러를 수정하였습니다.

## 기타 작업 사항
- 메뉴 항목이 적을 때, gray100 영역이 잘리고 흰 배경이 나오던 현상을 수정하였습니다. 

|전|후|
|---|---|
|<img width="294" alt="스크린샷 2024-03-19 오전 2 24 44" src="https://github.com/EAT-SSU/Android/assets/94737714/5982404f-d66f-4d20-88f3-109ddad946ec">|<img width="277" alt="스크린샷 2024-03-19 오전 2 22 24" src="https://github.com/EAT-SSU/Android/assets/94737714/c74acfcb-311c-4889-bf69-34d051e6fa7b">|