### PR TITLE
[Fix/#173] 강제 업데이트 방식 변경, 고정메뉴 빈 리스트 로직 변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         minSdk 23
         compileSdkVersion 34
         targetSdk 34
-        versionCode 11
-        versionName "1.1.9"
+        versionCode 10
+        versionName "1.1.8"
 
 
         buildConfigField "String", "BASE_URL", properties["BASE_URL"]

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         minSdk 23
         compileSdkVersion 34
         targetSdk 34
-        versionCode 10
-        versionName "1.1.8"
+        versionCode 11
+        versionName "1.1.9"
 
 
         buildConfigField "String", "BASE_URL", properties["BASE_URL"]

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,6 +125,9 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:32.2.2')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-crashlytics'
+
+    //Timer
+    implementation "com.jakewharton.timber:timber:5.0.1"
 }
 
 kapt {

--- a/app/src/main/java/com/eatssu/android/App.kt
+++ b/app/src/main/java/com/eatssu/android/App.kt
@@ -5,22 +5,21 @@ import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 
 @HiltAndroidApp
 class App: Application() {
     companion object{
         lateinit var appContext : Context
-//        lateinit var token_prefs : TokenSharedPreferences
     }
 
     override fun onCreate() {
         super.onCreate()
         FirebaseApp.initializeApp(this)
 
-//        token_prefs = TokenSharedPreferences(applicationContext)
-
         appContext = this
         KakaoSdk.init(this,BuildConfig.KAKAO_NATIVE_APP_KEY)
 
+        Timber.plant(Timber.DebugTree())
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
+++ b/app/src/main/java/com/eatssu/android/data/repository/FirebaseRemoteConfigRepository.kt
@@ -1,6 +1,5 @@
 package com.eatssu.android.data.repository
 
-import android.util.Log
 import com.eatssu.android.R
 import com.eatssu.android.data.model.AndroidMessage
 import com.eatssu.android.data.model.RestaurantInfo
@@ -8,6 +7,7 @@ import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.google.gson.Gson
 import org.json.JSONArray
+import timber.log.Timber
 
 class FirebaseRemoteConfigRepository {
     private val instance = FirebaseRemoteConfig.getInstance()
@@ -23,10 +23,10 @@ class FirebaseRemoteConfigRepository {
         // Set the default values locally
         instance.fetchAndActivate().addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                Log.d("FirebaseRemoteConfigRepository", "fetchAndActivate 성공")
+                Timber.d("fetchAndActivate 성공")
             } else {
                 // Handle error
-                Log.d("FirebaseRemoteConfigRepository", "fetchAndActivate error")
+                Timber.d("fetchAndActivate error")
                 instance.setDefaultsAsync(R.xml.firebase_remote_config)
 //                throw RuntimeException("fetchAndActivate 실패")
             }
@@ -53,6 +53,10 @@ class FirebaseRemoteConfigRepository {
         return instance.getString("app_version")
     }
 
+    fun getVersionCode(): Long {
+        return instance.getLong("android_version_code")
+    }
+
     fun getCafeteriaInfo(): ArrayList<RestaurantInfo> {
         return parsingJson(instance.getString("cafeteria_info"))
     }
@@ -70,7 +74,7 @@ class FirebaseRemoteConfigRepository {
             val etc = jsonObject.optString("etc", "")
 
             val restaurantInfo = RestaurantInfo(name, location, time, etc)
-            Log.d("FirebaseRemoteConfigRepository", restaurantInfo.toString())
+            Timber.d(restaurantInfo.toString())
             list.add(restaurantInfo)
         }
         return list

--- a/app/src/main/java/com/eatssu/android/ui/common/VersionViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/ui/common/VersionViewModel.kt
@@ -1,9 +1,10 @@
 package com.eatssu.android.ui.common
 
 import androidx.lifecycle.ViewModel
-import com.eatssu.android.BuildConfig.VERSION_NAME
+import com.eatssu.android.BuildConfig.VERSION_CODE
 import com.eatssu.android.data.model.AndroidMessage
 import com.eatssu.android.data.repository.FirebaseRemoteConfigRepository
+import timber.log.Timber
 
 class VersionViewModel(private val repository: FirebaseRemoteConfigRepository) : ViewModel() {
 
@@ -13,12 +14,28 @@ class VersionViewModel(private val repository: FirebaseRemoteConfigRepository) :
     }
 
     fun checkForceUpdate(): Boolean {
-        val lastVersion = checkAppVersion()
-        return VERSION_NAME != lastVersion && repository.getForceUpdate()
+
+        val versionCode = checkVersionCode() //얘가 파이어베이스에 있는 최신 버전
+        val thisCheckVersionCode = VERSION_CODE
+
+        Timber.d("앱의 versionCode는 " + thisCheckVersionCode + " 배포된 최신 버전은 " + versionCode)
+
+        if (thisCheckVersionCode < versionCode) { //배포된 버전이 크면 강제 업데이트
+            Timber.d("강제업데이트")
+            return true
+        } else if (thisCheckVersionCode >= versionCode) { //이 버전이 더 크거나 같으면 강제 업데이트 할 필요 x
+            Timber.d("업데이트 패스~")
+            return false
+        }
+        return false
     }
 
     fun checkAppVersion(): String {
         return repository.getAppVersion()
+    }
+
+    fun checkVersionCode(): Long {
+        return repository.getVersionCode()
     }
 
     fun checkAndroidMessage(): AndroidMessage {

--- a/app/src/main/java/com/eatssu/android/ui/main/menu/MenuFragment.kt
+++ b/app/src/main/java/com/eatssu/android/ui/main/menu/MenuFragment.kt
@@ -83,7 +83,7 @@ class MenuFragment : Fragment() {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    fun observeViewModel(){
+    fun observeViewModel() {
         menuService = RetrofitImpl.retrofit.create(MenuService::class.java)
         mealService = RetrofitImpl.retrofit.create(MealService::class.java)
 
@@ -108,7 +108,8 @@ class MenuFragment : Fragment() {
         // ViewModel에서 데이터 가져오기
         calendarViewModel.getData().observe(viewLifecycleOwner) { dataReceived ->
 
-            val parsedDate = LocalDate.parse(dataReceived.toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+            val parsedDate =
+                LocalDate.parse(dataReceived.toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"))
             menuDate = parsedDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
 
             // Assuming menuDate is a String in the format "yyyyMMdd"
@@ -122,30 +123,37 @@ class MenuFragment : Fragment() {
                 //푸드코트
                 menuViewModel.loadFixedMenu(Restaurant.FOOD_COURT)
                 menuViewModel.fixedMenuDataFood.observe(viewLifecycleOwner) { result ->
-                    totalMenuList.add(
-                        Section(
-                            MenuType.FIXED,
-                            Restaurant.FOOD_COURT,
-                            result.mapFixedMenuResponseToMenu()
+                    if (result.mapFixedMenuResponseToMenu().isNotEmpty()) {
+                        Log.d("menu", result.categoryMenuListCollection.toString())
+                        totalMenuList.add(
+                            Section(
+                                MenuType.FIXED,
+                                Restaurant.FOOD_COURT,
+                                result.mapFixedMenuResponseToMenu()
+                            )
                         )
-                    )
+                    }
                     foodCourtDataLoaded.value = true
                     checkDataLoaded()
+//
                 }
 
                 //스낵코너
                 menuViewModel.loadFixedMenu(Restaurant.SNACK_CORNER)
                 menuViewModel.fixedMenuDataSnack.observe(viewLifecycleOwner) { result ->
-                    totalMenuList.add(
-                        Section(
-                            MenuType.FIXED,
-                            Restaurant.SNACK_CORNER,
-                            result.mapFixedMenuResponseToMenu()
+                    if (result.mapFixedMenuResponseToMenu().isNotEmpty()) {
+                        totalMenuList.add(
+                            Section(
+                                MenuType.FIXED,
+                                Restaurant.SNACK_CORNER,
+                                result.mapFixedMenuResponseToMenu()
+                            )
                         )
-                    )
+                    }
                     snackCornerDataLoaded.value = true
                     checkDataLoaded()
                 }
+
                 Log.d("MenuFragment", "The date $menuDate is not on a weekend.")
             }
 
@@ -157,12 +165,11 @@ class MenuFragment : Fragment() {
                 Log.d("MenuFragment", "The date $menuDate is not on a weekend.")
             }
 
-            if(time!= Time.LUNCH){
+            if (time != Time.LUNCH) {
                 foodCourtDataLoaded.value = true //푸드코트
                 snackCornerDataLoaded.value = true //스낵코너
                 checkDataLoaded()
             }
-
 
 
             //학생식당

--- a/app/src/main/java/com/eatssu/android/ui/mypage/MyPageActivity.kt
+++ b/app/src/main/java/com/eatssu/android/ui/mypage/MyPageActivity.kt
@@ -3,7 +3,6 @@ package com.eatssu.android.ui.mypage
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
@@ -25,6 +24,7 @@ import com.eatssu.android.util.extension.startActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MyPageActivity : BaseActivity<ActivityMyPageBinding>(ActivityMyPageBinding::inflate) {
@@ -100,13 +100,13 @@ class MyPageActivity : BaseActivity<ActivityMyPageBinding>(ActivityMyPageBinding
     }
 
     private fun setData() {
-        binding.tvAppVersion.text = BuildConfig.VERSION_NAME
-        binding.tvStoreAppVersion.text = versionViewModel.checkAppVersion()
+        binding.tvAppVersion.text = BuildConfig.VERSION_NAME + " (" + BuildConfig.VERSION_CODE + ")"
+        binding.tvStoreAppVersion.text = versionViewModel.checkVersionCode().toString()
 
         myPageViewModel.getMyInfo()
 
         lifecycleScope.launch {
-            Log.d(TAG, "관찰시작")
+            Timber.d("관찰시작")
             myPageViewModel.uiState.collectLatest {
                 if (!it.error && !it.loading) {
                     binding.tvNickname.text = it.nickname
@@ -201,9 +201,5 @@ class MyPageActivity : BaseActivity<ActivityMyPageBinding>(ActivityMyPageBinding
                 )
             )
         }
-    }
-
-    companion object {
-        val TAG = "MyPageActivity"
     }
 }

--- a/app/src/main/res/xml/firebase_remote_config.xml
+++ b/app/src/main/res/xml/firebase_remote_config.xml
@@ -5,6 +5,10 @@
         <value>false</value>
     </entry>
     <entry>
+        <key>android_version_code</key>
+        <value>1</value>
+    </entry>
+    <entry>
         <key>latest_app_version</key>
         <value>1.0.0</value>
     </entry>


### PR DESCRIPTION
## Summary
1. 고정 메뉴에 빈 리스트가 들어오면 식당 리스트에서 아예 빼도록 처리 했습니다.
-> 푸드코트는 카테고리만 존재하고 하위 메뉴가 없으므로 이번 로직으로 인해 메뉴 리스트에서 사라지도록 처리하였습니다. 

2. 강제 업데이트 방식을 버전 네임(1.1.1)에서 버전 코드로 (1) 방식을 변경하였습니다. 그리고 해당 버전보다 작을시에만 강제 업데이트를 허용하였습니다. (이전에는 다를시에 강제 업데이트였음)

3. 로깅에 Log 대신 Timber를 사용하도록 하였습니다. 
사유: Companion object 안에 TAG = "파일명"으로 로그 태그를 만들어서 넣었었는데, 반복되고 귀찮은 보일러 플레이트 코드로 생각이 들었습니다. 반면에 Timber는 TAG를 지정하지 않으면 자동으로 해당 파일명을 태그로 사용하기 때문에 해결이 가능합니다! (물론 태그 지정도 가능합니다.)

## Issue

- Resolves #173

