### PR TITLE
[Fix/#139] 리뷰 수정시 정보가 안넘어가던 현상 고치기

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "com.eatssu.android"
         minSdk 23
         targetSdk 34
-        versionCode 16
-        versionName "1.1.14"
+        versionCode 17
+        versionName "1.1.15"
 
 
         buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"${properties.get('KAKAO_NATIVE_APP_KEY')}\"")

--- a/app/src/main/java/com/eatssu/android/data/service/ReviewService.kt
+++ b/app/src/main/java/com/eatssu/android/data/service/ReviewService.kt
@@ -23,7 +23,7 @@ interface ReviewService {
         @Path("reviewId") reviewId: Long,
     ): Call<BaseResponse<Void>>
 
-    @PATCH("/review/{reviewId}") //리뷰 수정(글 수정)
+    @PATCH("/reviews/{reviewId}") //리뷰 수정(글 수정)
     fun modifyReview(
         @Path("reviewId") reviewId: Long,
         @Body request: ModifyReviewRequest,

--- a/app/src/main/java/com/eatssu/android/ui/mypage/myreview/MyReviewAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/ui/mypage/myreview/MyReviewAdapter.kt
@@ -50,10 +50,17 @@ class MyReviewAdapter(private val dataList: List<Review>) :
                 val intent = Intent(binding.btnDetail.context, MyReviewDialogActivity::class.java)
                 intent.putExtra("reviewId", dataList[position].reviewId)
                 intent.putExtra("menu", dataList[position].menu)
-                intent.putExtra("comment", dataList[position].content)
-                intent.putExtra("amountRating", dataList[position].amountGrade)
-                intent.putExtra("tasteRating", dataList[position].tasteGrade)
-                intent.putExtra("mainRating", dataList[position].mainGrade)
+
+                intent.putExtra("content", dataList[position].content)
+
+                intent.putExtra("mainGrade", dataList[position].mainGrade)
+                intent.putExtra("amountGrade", dataList[position].amountGrade)
+                intent.putExtra("tasteGrade", dataList[position].tasteGrade)
+
+                Log.d("ReviewFixedActivity", "전전:" + dataList[position].reviewId)
+                Log.d("ReviewFixedActivity", "전전:" + dataList[position].menu)
+                Log.d("ReviewFixedActivity", "전전:" + dataList[position].content)
+////
                 ContextCompat.startActivity(binding.btnDetail.context, intent, null)
             }
         }

--- a/app/src/main/java/com/eatssu/android/ui/review/delete/MyReviewDialogActivity.kt
+++ b/app/src/main/java/com/eatssu/android/ui/review/delete/MyReviewDialogActivity.kt
@@ -14,27 +14,42 @@ import com.eatssu.android.ui.review.modify.ModifyReviewActivity
 class MyReviewDialogActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMyReviewDialogBinding
     private lateinit var viewModel: DeleteViewModel
+
     var reviewId = -1L
     var menu = ""
+    var content = ""
+    var mainGrade = -1
+    var amountGrade = -1
+    var tasteGrade = -1
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = ActivityMyReviewDialogBinding.inflate(layoutInflater)
-
         setContentView(binding.root)
 
         viewModel = ViewModelProvider(this).get(DeleteViewModel::class.java)
 
         reviewId = intent.getLongExtra("reviewId", -1L)
         menu = intent.getStringExtra("menu").toString()
+        content = intent.getStringExtra("content").toString()
+        mainGrade = intent.getIntExtra("mainGrade", -1)
+        amountGrade = intent.getIntExtra("amountGrade", -1)
+        tasteGrade = intent.getIntExtra("tasteGrade", -1)
 
-        Log.d("reviewId", reviewId.toString())
+        Log.d("ReviewFixedActivity", "전:" + reviewId.toString())
+        Log.d("ReviewFixedActivity", "전:" + menu.toString())
+        Log.d("ReviewFixedActivity", "전:" + content.toString())
 
         binding.btnReviewFix.setOnClickListener {
             val intent = Intent(this, ModifyReviewActivity::class.java)
             intent.putExtra("reviewId", reviewId)
             intent.putExtra("menu", menu)
+            intent.putExtra("content", content)
+            intent.putExtra("mainGrade", mainGrade)
+            intent.putExtra("amountGrade", amountGrade)
+            intent.putExtra("tasteGrade", tasteGrade)
+
             startActivity(intent)
             finish()
         }

--- a/app/src/main/java/com/eatssu/android/ui/review/list/ReviewAdapter.kt
+++ b/app/src/main/java/com/eatssu/android/ui/review/list/ReviewAdapter.kt
@@ -60,11 +60,15 @@ class ReviewAdapter(private val dataList: List<Review>) :
                         Intent(binding.btnDetail.context, MyReviewDialogActivity::class.java)
                     intent.putExtra("reviewId", data.reviewId)
                     intent.putExtra("menu", data.menu)
-                    intent.putExtra("comment", data.content)
-                    intent.putExtra("mainRating", data.mainGrade)
-                    intent.putExtra("amountRating", data.amountGrade)
-                    intent.putExtra("tasteRating", data.tasteGrade)
-                    Log.d("ReviewAdapter", data.toString())
+                    intent.putExtra("content", data.content)
+                    intent.putExtra("mainGrade", data.mainGrade)
+                    intent.putExtra("amountGrade", data.amountGrade)
+                    intent.putExtra("tasteGrade", data.tasteGrade)
+
+                    Log.d("ReviewFixedActivity", "전전:" + data.reviewId)
+                    Log.d("ReviewFixedActivity", "전전:" + data.menu)
+                    Log.d("ReviewFixedActivity", "전전:" + data.content)
+////                    Timber.d("내용: "+data.content)
                     ContextCompat.startActivity(binding.btnDetail.context, intent, null)
                 }
             }

--- a/app/src/main/java/com/eatssu/android/ui/review/modify/ModifyReviewActivity.kt
+++ b/app/src/main/java/com/eatssu/android/ui/review/modify/ModifyReviewActivity.kt
@@ -52,7 +52,7 @@ class ModifyReviewActivity : BaseActivity<ActivityFixMenuBinding>(ActivityFixMen
 
         main = intent.getIntExtra("mainGrade", 0)
         amount = intent.getIntExtra("amountGrade", 0)
-        taste = intent.getIntExtra("amountGrade", 0)
+        taste = intent.getIntExtra("tasteGrade", 0)
 
         Log.d("ReviewFixedActivity", reviewId.toString() + menu)
         Log.d("ReviewFixedActivity", content)
@@ -63,7 +63,7 @@ class ModifyReviewActivity : BaseActivity<ActivityFixMenuBinding>(ActivityFixMen
         binding.etReview2Comment.setText(content)
         binding.rbMain.rating = main.toFloat()
         binding.rbAmount.rating = intent.getIntExtra("amountGrade", 0).toFloat()
-        binding.rbTaste.rating = intent.getIntExtra("amountGrade", 0).toFloat()
+        binding.rbTaste.rating = intent.getIntExtra("tasteGrade", 0).toFloat()
     }
 
     private fun postData(reviewId: Long) {

--- a/app/src/main/java/com/eatssu/android/ui/review/modify/ModifyReviewActivity.kt
+++ b/app/src/main/java/com/eatssu/android/ui/review/modify/ModifyReviewActivity.kt
@@ -13,12 +13,15 @@ import kotlinx.coroutines.launch
 class ModifyReviewActivity : BaseActivity<ActivityFixMenuBinding>(ActivityFixMenuBinding::inflate) {
 
     private lateinit var viewModel: ModifyViewModel
+
     private var reviewId = -1L
     private var menu = ""
+
+    private var content = ""
+
+    private var main = 0
     private var amount = 0
     private var taste = 0
-    private var main = 0
-    private var content = ""
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         toolbarTitle.text = "리뷰 수정하기" // 툴바 제목 설정
@@ -42,24 +45,25 @@ class ModifyReviewActivity : BaseActivity<ActivityFixMenuBinding>(ActivityFixMen
     }
 
     private fun getIndex() {
+
         reviewId = intent.getLongExtra("reviewId", -1L)
         menu = intent.getStringExtra("menu").toString()
-        content = intent.getStringExtra("comment").toString()
+        content = intent.getStringExtra("content").toString()
 
-        main = intent.getIntExtra("mainRating", 0)
-        amount = intent.getIntExtra("amountRating", 0)
-        taste = intent.getIntExtra("tasteRating", 0)
+        main = intent.getIntExtra("mainGrade", 0)
+        amount = intent.getIntExtra("amountGrade", 0)
+        taste = intent.getIntExtra("amountGrade", 0)
 
         Log.d("ReviewFixedActivity", reviewId.toString() + menu)
         Log.d("ReviewFixedActivity", content)
     }
 
     private fun setData() {
-        binding.menu.text = intent.getStringExtra("menu").toString()
-        binding.etReview2Comment.setText(intent.getStringExtra("content"))
-        binding.rbMain.rating = intent.getIntExtra("mainRating", 0).toFloat()
-        binding.rbAmount.rating = intent.getIntExtra("amountRating", 0).toFloat()
-        binding.rbTaste.rating = intent.getIntExtra("tasteRating", 0).toFloat()
+        binding.menu.text = menu
+        binding.etReview2Comment.setText(content)
+        binding.rbMain.rating = main.toFloat()
+        binding.rbAmount.rating = intent.getIntExtra("amountGrade", 0).toFloat()
+        binding.rbTaste.rating = intent.getIntExtra("amountGrade", 0).toFloat()
     }
 
     private fun postData(reviewId: Long) {


### PR DESCRIPTION
## Summary
리뷰 수정시 정보가 안넘어가던 현상 고치기
리뷰 수정이지만 다 정보가 다 빈칸으로 들어갔었음.
이제는 잘 됨!

## Describe your changes
<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
- endpoint `review` -> `reviews` 
- DTO `XXXrating` -> `XXXgrade`

## Issue

- Resolves #139

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->

### Trouble Shooting1 네이밍 잘보기
- endpoint `review` -> `reviews` 
- DTO `XXXrating` -> `XXXgrade`
- 네이밍 수정 된 것을 캐치하지 못해 시간이 지체되었음

### Todo
-  리뷰 수정 화면 UI 손보기
-  intent를 두번 넘기는 코드가 신경쓰임. 추후 뷰모델로 수정할 수 있도록.

