### PR TITLE
[Refactor/#167] Hilt를 통해 ApplicationContext 주입하기

### DIFF
--- a/app/src/main/java/com/eatssu/android/data/usecase/GetAccessTokenUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/GetAccessTokenUseCase.kt
@@ -1,14 +1,14 @@
 package com.eatssu.android.data.usecase
 
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class GetAccessTokenUseCase @Inject constructor(
-//    private val preferencesRepository: PreferencesRepository,
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(): String {
-
-        return MySharedPreferences.getAccessToken(App.appContext)
+        return MySharedPreferences.getAccessToken(context)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/GetRefreshTokenUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/GetRefreshTokenUseCase.kt
@@ -1,14 +1,15 @@
 package com.eatssu.android.data.usecase
 
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class GetRefreshTokenUseCase @Inject constructor(
+    @ApplicationContext private val context: Context
 //    private val preferencesRepository: PreferencesRepository,
 ) {
     suspend operator fun invoke(): String {
-
-        return MySharedPreferences.getRefreshToken(App.appContext)
+        return MySharedPreferences.getRefreshToken(context)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/GetUserEmailUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/GetUserEmailUseCase.kt
@@ -1,14 +1,15 @@
 package com.eatssu.android.data.usecase
 
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class GetUserEmailUseCase @Inject constructor(
-//    private val preferencesRepository: PreferencesRepository,
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(): String {
 
-        return MySharedPreferences.getUserEmail(App.appContext)
+        return MySharedPreferences.getUserEmail(context)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/GetUserNameUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/GetUserNameUseCase.kt
@@ -1,14 +1,15 @@
 package com.eatssu.android.data.usecase
 
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class GetUserNameUseCase @Inject constructor(
 //    private val preferencesRepository: PreferencesRepository,
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(): String {
-
-        return MySharedPreferences.getUserName(App.appContext)
+        return MySharedPreferences.getUserName(context)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/LogoutUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/LogoutUseCase.kt
@@ -1,14 +1,16 @@
 package com.eatssu.android.data.usecase
 
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke() {
 
-        MySharedPreferences.clearUser(App.appContext)
+        MySharedPreferences.clearUser(context)
 
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/SetAccessTokenUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/SetAccessTokenUseCase.kt
@@ -1,17 +1,15 @@
 package com.eatssu.android.data.usecase
 
-import android.util.Log
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class SetAccessTokenUseCase @Inject constructor(
 //    private val preferencesRepository: PreferencesRepository,
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(accessToken: String) {
-        MySharedPreferences.setAccessToken(App.appContext, accessToken)
-
-        Log.d("SetAccessTokenUseCase", accessToken)
-
+        MySharedPreferences.setAccessToken(context, accessToken)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/SetRefreshTokenUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/SetRefreshTokenUseCase.kt
@@ -1,17 +1,15 @@
 package com.eatssu.android.data.usecase
 
-import android.util.Log
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class SetRefreshTokenUseCase @Inject constructor(
 //    private val preferencesRepository: PreferencesRepository,
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(refreshToken: String) {
-        MySharedPreferences.setRefreshToken(App.appContext, refreshToken)
-
-        Log.d("SetRefreshTokenUseCase", refreshToken)
-
+        MySharedPreferences.setRefreshToken(context, refreshToken)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/SetUserEmailUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/SetUserEmailUseCase.kt
@@ -1,16 +1,14 @@
 package com.eatssu.android.data.usecase
 
-import android.util.Log
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class SetUserEmailUseCase @Inject constructor(
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(email: String) {
-        MySharedPreferences.setUserEmail(App.appContext, email)
-
-        Log.d("SetUserEmailUseCase", email)
-
+        MySharedPreferences.setUserEmail(context, email)
     }
 }

--- a/app/src/main/java/com/eatssu/android/data/usecase/SetUserNameUseCase.kt
+++ b/app/src/main/java/com/eatssu/android/data/usecase/SetUserNameUseCase.kt
@@ -1,18 +1,20 @@
 package com.eatssu.android.data.usecase
 
-import com.eatssu.android.App
+import android.content.Context
 import com.eatssu.android.base.BaseResponse
 import com.eatssu.android.data.dto.request.ChangeNicknameRequest
 import com.eatssu.android.data.repository.UserRepository
 import com.eatssu.android.util.MySharedPreferences
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class SetUserNameUseCase @Inject constructor(
     private val userRepository: UserRepository,
+    @ApplicationContext private val context: Context
 ) {
     suspend operator fun invoke(name: String): Flow<BaseResponse<Void>> {
-        MySharedPreferences.setUserName(App.appContext, name)
+        MySharedPreferences.setUserName(context, name)
         //Todo 이게 최선일까? 로컬에 이름 Set과 리모트의 이름 change를 usecase를 따로 만들어야하나?
 
         return userRepository.updateUserName(ChangeNicknameRequest(name))

--- a/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
+++ b/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
@@ -1,12 +1,12 @@
 package com.eatssu.android.di.network
 
 
+import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.widget.Toast
-import com.eatssu.android.App
 import com.eatssu.android.BuildConfig.BASE_URL
 import com.eatssu.android.base.BaseResponse
 import com.eatssu.android.data.dto.response.TokenResponse
@@ -18,6 +18,7 @@ import com.eatssu.android.data.usecase.SetRefreshTokenUseCase
 import com.eatssu.android.ui.login.LoginActivity
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -33,6 +34,7 @@ class TokenInterceptor @Inject constructor(
     private val setAccessTokenUseCase: SetAccessTokenUseCase,
     private val setRefreshTokenUseCase: SetRefreshTokenUseCase,
     private val logoutUseCase: LogoutUseCase,
+    @ApplicationContext private val context: Context
 ) : Interceptor {
 
     companion object {
@@ -110,7 +112,7 @@ class TokenInterceptor @Inject constructor(
                     Timber.e("재발급에서의 401")
 
                     Handler(Looper.getMainLooper()).post {
-                        val context = App.appContext
+                        val context = context
                         Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                         val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
@@ -123,7 +125,7 @@ class TokenInterceptor @Inject constructor(
                 Timber.e("재발급 실패 $e")
 
                 Handler(Looper.getMainLooper()).post {
-                    val context = App.appContext
+                    val context = context
                     Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                     val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
@@ -137,7 +139,7 @@ class TokenInterceptor @Inject constructor(
             Timber.e("404 + 다른 유저!")
 
             Handler(Looper.getMainLooper()).post {
-                val context = App.appContext
+                val context = context
                 Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                 val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
@@ -150,7 +152,7 @@ class TokenInterceptor @Inject constructor(
             Timber.e("500 + 다른 유저")
 
             Handler(Looper.getMainLooper()).post {
-                val context = App.appContext
+                val context = context
                 Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                 val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
+++ b/app/src/main/java/com/eatssu/android/di/network/TokenInterceptor.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.widget.Toast
 import com.eatssu.android.BuildConfig.BASE_URL
 import com.eatssu.android.base.BaseResponse
@@ -70,7 +69,7 @@ class TokenInterceptor @Inject constructor(
         val response = chain.proceed(request)
 
         if (response.code == 401) {
-            Log.d(TAG, "토큰 퉤퉤")
+            Timber.d("토큰 퉤퉤")
             response.close()
 
             try {
@@ -80,13 +79,13 @@ class TokenInterceptor @Inject constructor(
                     .addHeader(HEADER_AUTHORIZATION, "Bearer $refreshToken")
                     .build()
 
-                Log.d(TAG, "재발급 중")
+                Timber.d("재발급 중")
 
                 val refreshTokenResponse = chain.proceed(refreshTokenRequest)
-                Log.d(TAG, "refreshTokenResponse : $refreshTokenResponse")
+                Timber.d("refreshTokenResponse : $refreshTokenResponse")
 
                 if (refreshTokenResponse.isSuccessful) {
-                    Log.d(TAG, "재발급 성공")
+                    Timber.d("재발급 성공")
 
                     val responseToken = parseRefreshTokenResponse(refreshTokenResponse)
 
@@ -112,7 +111,6 @@ class TokenInterceptor @Inject constructor(
                     Timber.e("재발급에서의 401")
 
                     Handler(Looper.getMainLooper()).post {
-                        val context = context
                         Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                         val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
@@ -125,7 +123,6 @@ class TokenInterceptor @Inject constructor(
                 Timber.e("재발급 실패 $e")
 
                 Handler(Looper.getMainLooper()).post {
-                    val context = context
                     Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                     val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
@@ -139,7 +136,6 @@ class TokenInterceptor @Inject constructor(
             Timber.e("404 + 다른 유저!")
 
             Handler(Looper.getMainLooper()).post {
-                val context = context
                 Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                 val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
@@ -152,7 +148,6 @@ class TokenInterceptor @Inject constructor(
             Timber.e("500 + 다른 유저")
 
             Handler(Looper.getMainLooper()).post {
-                val context = context
                 Toast.makeText(context, "토큰이 만료되어 로그아웃 됩니다.", Toast.LENGTH_SHORT).show()
                 val intent = Intent(context, LoginActivity::class.java) // 로그인 화면으로 이동
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/com/eatssu/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/ui/login/LoginViewModel.kt
@@ -1,8 +1,8 @@
 package com.eatssu.android.ui.login
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.eatssu.android.App
 import com.eatssu.android.R
 import com.eatssu.android.data.dto.request.LoginWithKakaoRequest
 import com.eatssu.android.data.usecase.LoginUseCase
@@ -10,6 +10,7 @@ import com.eatssu.android.data.usecase.SetAccessTokenUseCase
 import com.eatssu.android.data.usecase.SetRefreshTokenUseCase
 import com.eatssu.android.data.usecase.SetUserEmailUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,6 +29,7 @@ class LoginViewModel @Inject constructor(
     private val setAccessTokenUseCase: SetAccessTokenUseCase,
     private val setRefreshTokenUseCase: SetRefreshTokenUseCase,
     private val setUserEmailUseCase: SetUserEmailUseCase,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<LoginState> = MutableStateFlow(LoginState())
@@ -46,7 +48,7 @@ class LoginViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         loading = false, error = false,
-                        toastMessage = App.appContext.getString(R.string.login_done)
+                        toastMessage = context.getString(R.string.login_done)
                     )
                     //Todo 로그인과 회원가입에 따른 토스트 메시지 구분하기
                 }

--- a/app/src/main/java/com/eatssu/android/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/eatssu/android/ui/main/MainViewModel.kt
@@ -1,11 +1,12 @@
 package com.eatssu.android.ui.main
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.eatssu.android.App
 import com.eatssu.android.R
 import com.eatssu.android.data.usecase.GetUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val getUserInfoUseCase: GetUserInfoUseCase,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<MainState> = MutableStateFlow(MainState())
@@ -40,7 +42,7 @@ class MainViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         error = true,
-                        toastMessage = App.appContext.getString(R.string.not_found)
+                        toastMessage = context.getString(R.string.not_found)
                     )
                 }
                 Timber.e(e.toString())
@@ -51,7 +53,7 @@ class MainViewModel @Inject constructor(
                         _uiState.update {
                             it.copy(
                                 isNicknameNull = true,
-                                toastMessage = App.appContext.getString(R.string.set_nickname)
+                                toastMessage = context.getString(R.string.set_nickname)
                             )
                         }
                     } else {
@@ -59,7 +61,7 @@ class MainViewModel @Inject constructor(
                             it.copy(
                                 isNicknameNull = false,
                                 toastMessage = String.format(
-                                    App.appContext.getString(R.string.hello_user),
+                                    context.getString(R.string.hello_user),
                                     this.nickname
                                 )
                             )


### PR DESCRIPTION
## Summary
<!-- 무슨 이유로 코드를 변경했는지 -->
<!-- 테스트 계획 또는 완료 사항 -->
Application context를 Hilt를 통해 생성하자 

|as is |to be|
|--|--|
|companion object를 사용해 App 클래스에서 Context를 전역적으로 관리하고 호출|Hilt를 통해 @ApplicationContext를 주입하여 필요한 곳에서 Context를 사용|

## Describe your changes

### 선언
```kotlin
@Module
@InstallIn(SingletonComponent::class)
object AppModule {

    @Provides
    @Singleton
    fun provideContext(application: Application): Context {
        return application.applicationContext
    }
}
```
(해당 수정은 이전 PR에서 추가된 내용이라 files changed에 나타나지 않습니다.)

<!-- 변경 또는 추가된 코드, 관련 스크린샷 -->
### 사용 방법
- 전
```kotlin
class GetAccessTokenUseCase @Inject constructor(
) {
    suspend operator fun invoke(): String {

        return MySharedPreferences.getAccessToken(App.appContext)
    }
}
```

- 후
```kotlin
class GetAccessTokenUseCase @Inject constructor(
    @ApplicationContext private val context: Context
) {
    suspend operator fun invoke(): String {
        return MySharedPreferences.getAccessToken(context)
    }
}
```


## Issue

- Resolves #167

## To reviewers
<!-- 어떤 위험이나 장애가 발견되었는지 -->
<!-- 어떤 부분에 리뷰어가 집중하면 좋을지 -->


App class에 있는 변수를 지우진 않았음 -> 리팩로링이 완전히 진행되지 않아 완벽히 지우지는 못하였다.
